### PR TITLE
fix: return error if user already is member of the team

### DIFF
--- a/packages/api/src/modules/invite/resolvers/acceptInvite.ts
+++ b/packages/api/src/modules/invite/resolvers/acceptInvite.ts
@@ -20,6 +20,10 @@ export const acceptInvite = async (args: MutationAcceptInviteArgs, ctx: GraphQLC
 
     const foundedUser = await UserModel.findById(ctx.user.id);
 
+    if (foundedUser?.teamId.toString() === decodedToken.teamId) {
+      return { Error: ['You already is a member of this team'] };
+    }
+
     const userUpdated = await UserModel.findByIdAndUpdate(
       ctx.user.id,
       { teamId: decodedToken.teamId, role: { name: 'member' } },


### PR DESCRIPTION
# Description

Return error if user already is member of the team

Fixes #33 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules